### PR TITLE
fix: remove "A project should have `requirements.txt`", as requirements may be stored in `requirements/` folder

### DIFF
--- a/styles/file-structure.toml
+++ b/styles/file-structure.toml
@@ -5,6 +5,5 @@
 
 [nitpick.files.present]
 "README.md" = "A project should have `README.md`"
-"requirements.txt" = "A project should have `requirements.txt`"
 ".gitignore" = "A project should have `.gitignore` file"
 "setup.cfg" = "A project should have `setup.cfg` file"


### PR DESCRIPTION
fix: remove "A project should have `requirements.txt`", as requiremen…ts may be stored in `requirements/` folder