### PR TITLE
Add pre commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: catalyst-codestyle
+    name: catalyst-codestyle
+    description: 'makes code compatible with `catalyst` code style'
+    entry: catalyst-make-codestyle
+    language: python
+    types: [python]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,12 @@
--   id: catalyst-codestyle
-    name: catalyst-codestyle
+-   id: catalyst-make-codestyle
+    name: catalyst-make-codestyle
     description: 'makes code compatible with `catalyst` code style'
     entry: catalyst-make-codestyle
+    language: python
+    types: [python]
+-   id: catalyst-check-codestyle
+    name: catalyst-check-codestyle
+    description: 'checks that the code is `catalyst` code style compliant'
+    entry: catalyst-check-codestyle
     language: python
     types: [python]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,7 @@
     entry: catalyst-make-codestyle
     language: python
     types: [python]
+
 -   id: catalyst-check-codestyle
     name: catalyst-check-codestyle
     description: 'checks that the code is `catalyst` code style compliant'


### PR DESCRIPTION
Adds `pre-commit` hooks, which can be referred to and ran on commit/push/merge from any repository. I just tested this with my fork of `catalyst` and it works without any hiccup "on my machine" ( [link](https://github.com/Casyfill/catalyst/tree/pre-commit-hook) )

PR to catalyst main repo with use of those hooks is [here](https://github.com/catalyst-team/catalyst/pull/1257)

All docs on `pre-commit` are [here](https://pre-commit.com/#pre-commit-configyaml---hooks)

